### PR TITLE
INT-8228: gitignore typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ dist/
 .env
 .eslintcache
 tsconfig.tsbuildinfo
-.nmprc
+.npmrc


### PR DESCRIPTION
# Description
adding .npmrc to .gitignore to support all of the `auto` changes. wrong spelling on initial merge, broke the build.