### PR TITLE
Update version number to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-databricks",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A JupiterOne Integration for ingesting data for the Databricks",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
Seeing a weird issue with Auto and was able to recreate it locally.

Running
```sh
yarn auto shipit --dry-run --quiet
```
works perfectly fine and returns `1.2.0` as expected but running
```
yarn auto shipit
```
attempts to create the version `1.1.0`. Updating the package.json version to 1.2.0 to attempt to fix this issue in accordance with https://intuit.github.io/auto/docs/configuration/troubleshooting#you-cannot-publish-over-the-previously-published-versions